### PR TITLE
add step to install/test built package

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -22,6 +22,8 @@ jobs:
       run: python download.py
     - name: Build and sign
       run: python build.py ${{ matrix.pkg }}
+    - name: sanity check
+      run: python test.py ${{ matrix.pkg }}
     - name: Upload
       env:
         AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}

--- a/test.py
+++ b/test.py
@@ -1,0 +1,26 @@
+import argparse
+
+from utils import DockerBuilder
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("pkg", choices=["deb", "rpm"], help="package type")
+
+    args = parser.parse_args()
+
+    docker_dir = f"docker/{args.pkg}"
+    tag: str = f"dvc-s3-repo-{args.pkg}"
+    target = "pyenv"
+
+    image = DockerBuilder(
+        pkg=args.pkg,
+        tag=tag,
+        directory=docker_dir,
+        target=target,
+    )
+    image.run_test_package()
+
+
+if __name__ == "__main__":
+    main()

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+# basic functionality tests for dvc
+
+set -eux
+
+pkg=$1
+if [[ $pkg == "deb" ]]; then
+    dpkg -i dvc*.deb
+elif [[ $pkg == "rpm" ]]; then
+    rpm -i dvc*.rpm
+else
+    exit 1
+fi
+
+git clone https://github.com/iterative/example-get-started
+
+pushd example-get-started
+pip install -r src/requirements.txt
+
+dvc pull
+dvc repro
+dvc status

--- a/utils.py
+++ b/utils.py
@@ -17,7 +17,7 @@ class DockerBuilder:
         self,
         pkg: str,
         tag: str,
-        directory: str,
+        directory: Optional[str] = None,
         target: Optional[str] = None,
     ):
         self.client = docker.from_env()
@@ -117,4 +117,15 @@ class DockerBuilder:
         )
         if status:
             print(f"* Failed to build {self.pkg} package", file=sys.stderr)
+            sys.exit(status)
+
+    def run_test_package(self) -> None:
+        status = self.run(
+            command=f"./test.sh {self.pkg}",
+            volumes=self.volumes,
+            working_dir=str(self.working_dir),
+            auto_remove=True,
+        )
+        if status:
+            print(f"* Test for {self.pkg} package failed", file=sys.stderr)
             sys.exit(status)


### PR DESCRIPTION
add a step after building/signing the package(s) to install the package and test dvc in a few basic scenarios (pull/repro/status) using the [example-get-started](https://github.com/iterative/example-get-started)  repo