### PR TITLE
docker: use rbenv to install ruby

### DIFF
--- a/docker/deb/Dockerfile
+++ b/docker/deb/Dockerfile
@@ -1,4 +1,5 @@
 ARG PYTHON_VERSION=3.8.3
+ARG RUBY_VERSION=2.6.9
 
 FROM ubuntu:18.04 as pyenv
 ARG PYTHON_VERSION
@@ -37,10 +38,20 @@ RUN pyenv global ${PYTHON_VERSION}
 # make sure we're using the correct python version
 RUN test "${PYTHON_VERSION}" = "$(python --version | awk '{print $2}')"
 
-FROM pyenv as builder
+FROM pyenv as rbenv
+ARG RUBY_VERSION
+
+RUN curl -fsSL https://github.com/rbenv/rbenv-installer/raw/HEAD/bin/rbenv-installer | bash
+ENV RBENV_ROOT="/root/.rbenv"
+ENV PATH="$RBENV_ROOT/shims:$RBENV_ROOT/bin:$PATH"
+RUN rbenv install ${RUBY_VERSION}
+RUN rbenv global ${RUBY_VERSION}
+RUN ruby --version | grep ${RUBY_VERSION}
+
+FROM rbenv as builder
 
 RUN apt-get update && \
-    apt-get install -y jq rubygems apt-transport-https && \
+    apt-get install -y jq apt-transport-https && \
     rm -rf /var/lib/apt/lists/*
 
 RUN gem install fpm

--- a/docker/rpm/Dockerfile
+++ b/docker/rpm/Dockerfile
@@ -1,4 +1,5 @@
 ARG PYTHON_VERSION=3.8.3
+ARG RUBY_VERSION=2.6.9
 
 FROM centos:7 as pyenv
 ARG PYTHON_VERSION
@@ -34,7 +35,17 @@ RUN pyenv global ${PYTHON_VERSION}
 
 RUN test "${PYTHON_VERSION}" = "$(python --version | awk '{print $2}')"
 
-FROM pyenv as builder
+FROM pyenv as rbenv
+ARG RUBY_VERSION
+
+RUN curl -fsSL https://github.com/rbenv/rbenv-installer/raw/HEAD/bin/rbenv-installer | bash
+ENV RBENV_ROOT="/root/.rbenv"
+ENV PATH="$RBENV_ROOT/shims:$RBENV_ROOT/bin:$PATH"
+RUN rbenv install ${RUBY_VERSION}
+RUN rbenv global ${RUBY_VERSION}
+RUN ruby --version | grep ${RUBY_VERSION}
+
+FROM rbenv as builder
 
 RUN pip --no-cache install -U pip wheel
 
@@ -50,8 +61,7 @@ RUN yum -y install centos-release-scl-rh centos-release-scl
 RUN sed -i -e "s/\]$/\]\npriority=10/g" /etc/yum.repos.d/CentOS-SCLo-scl.repo
 RUN sed -i -e "s/\]$/\]\npriority=10/g" /etc/yum.repos.d/CentOS-SCLo-scl-rh.repo
 
-RUN yum install -y rh-ruby23
-RUN scl enable rh-ruby23 'gem install fpm'
+RUN gem install fpm
 
 COPY entrypoint.sh /usr/bin/entrypoint.sh
 


### PR DESCRIPTION
Some fpm dependencies started requiring ruby >= 2.6, so we need to upgrade. Can't use ruby from distro packages because they are way too old, so using rbenv instead.