### PR TITLE
rpm: use fedora 35 instead of centos 7

### DIFF
--- a/docker/rpm/Dockerfile
+++ b/docker/rpm/Dockerfile
@@ -1,13 +1,9 @@
 ARG PYTHON_VERSION=3.10.8
 ARG RUBY_VERSION=2.6.9
 
-FROM centos:7 as pyenv
+FROM fedora:35 as pyenv
 ARG PYTHON_VERSION
 
-ENV LC_ALL=en_US.UTF-8
-RUN localedef -c -f UTF-8 -i en_US en_US.UTF-8
-
-RUN yum install -y epel-release
 # https://github.com/pyenv/pyenv/wiki#suggested-build-environment
 # https://github.com/pyenv/pyenv/issues/2416
 RUN yum install -y \
@@ -20,25 +16,20 @@ RUN yum install -y \
         gcc \
         libffi-devel \
         openssl-devel \
-        openssl11 \
-        openssl11-libs \
-        openssl11-devel \
         readline-devel \
         sqlite \
         sqlite-devel \
         tk-devel \
         xz-devel \
-        zlib-devel
+        zlib-devel \
+        findutils
 
 RUN curl https://pyenv.run | bash
 
 ENV PYENV_ROOT="/root/.pyenv"
 ENV PATH="$PYENV_ROOT/shims:$PYENV_ROOT/bin:$PATH"
 
-RUN PYTHON_CONFIGURE_OPTS="--enable-shared" \
-    CPPFLAGS="$(pkg-config --cflags openssl11)" \
-    LDFLAGS="$(pkg-config --libs openssl11)" \
-    ~/.pyenv/bin/pyenv install ${PYTHON_VERSION}
+RUN PYTHON_CONFIGURE_OPTS="--enable-shared" ~/.pyenv/bin/pyenv install ${PYTHON_VERSION}
 RUN pyenv global ${PYTHON_VERSION}
 
 RUN test "${PYTHON_VERSION}" = "$(python --version | awk '{print $2}')"
@@ -59,15 +50,6 @@ RUN pip --no-cache install -U pip wheel
 
 # TODO: check if all of these dependencies are required
 RUN yum install -y wget jq yum-utils gnupg patch gdbm-devel ncurses-devel rpm-build
-RUN yum -y install yum-plugin-priorities
-RUN sed -i -e "s/\]$/\]\npriority=1/g" /etc/yum.repos.d/CentOS-Base.repo
-
-RUN yum -y install epel-release
-RUN sed -i -e "s/\]$/\]\npriority=5/g" /etc/yum.repos.d/epel.repo
-
-RUN yum -y install centos-release-scl-rh centos-release-scl
-RUN sed -i -e "s/\]$/\]\npriority=10/g" /etc/yum.repos.d/CentOS-SCLo-scl.repo
-RUN sed -i -e "s/\]$/\]\npriority=10/g" /etc/yum.repos.d/CentOS-SCLo-scl-rh.repo
 
 RUN gem install fpm
 

--- a/docker/rpm/Dockerfile
+++ b/docker/rpm/Dockerfile
@@ -53,12 +53,6 @@ RUN yum install -y wget jq yum-utils gnupg patch gdbm-devel ncurses-devel rpm-bu
 
 RUN gem install fpm
 
-COPY entrypoint.sh /usr/bin/entrypoint.sh
-
-RUN chmod +x /usr/bin/entrypoint.sh
-ENTRYPOINT [ "/usr/bin/entrypoint.sh" ]
-
-
 # NOTE: uploading with rpm-s3 requires python2
 FROM fedora:26 as uploader
 RUN dnf update -y && \

--- a/docker/rpm/entrypoint.sh
+++ b/docker/rpm/entrypoint.sh
@@ -1,3 +1,0 @@
-#!/bin/bash
-source scl_source enable rh-ruby23
-exec "$@"


### PR DESCRIPTION
Fedora 35 is the oldest fedora that is still not totally dead.

Note that we try to use the oldest distros possible to provide the best
compatibility with system libraries (e.g. libc).

Fixes #86