### PR TITLE
Update README install instructions (match docs)

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,17 +5,23 @@ Maintain deb and rpm repositories on s3
 ## Ubuntu, Debian
 Install dvc from dep repository:
 ```
-$ sudo cp deb/dvc.list /etc/apt/sources.list.d/
-$ sudo apt-key add iterative.asc
-$ sudo apt-get update
-$ sudo apt-get install dvc
+$ sudo wget \
+       https://dvc.org/deb/dvc.list \
+       -O /etc/apt/sources.list.d/dvc.list
+$ wget -qO - https://dvc.org/deb/iterative.asc | gpg --dearmor > packages.iterative.gpg
+$ sudo install -o root -g root -m 644 packages.iterative.gpg /etc/apt/trusted.gpg.d/
+$ rm -f packages.iterative.gpg
+$ sudo apt update
+$ sudo apt install dvc
 ```
 
 ## Fedora, Centos, RHEL
 Install dvc from rpm repository:
 ```
-$ sudo cp rpm/dvc.repo /etc/yum.repos.d/
+$ sudo wget \
+       https://dvc.org/rpm/dvc.repo \
+       -O /etc/yum.repos.d/dvc.repo
 $ sudo rpm --import https://dvc.org/rpm/iterative.asc
-$ sudo dnf update
-$ sudo dnf install dvc
+$ sudo yum update
+$ sudo yum install dvc
 ```


### PR DESCRIPTION
Whilst trying to install DVC into a Debian container on an M1 Mac (arch not supported btw) I came across the discrepancy between this README and the [docs](https://dvc.org/doc/install/linux#install-from-repository).

Please take a look and LMK if I have missed anything 🙏🏻.