### PR TITLE
Fix typo on `printenv`

### DIFF
--- a/rpm/upload.sh
+++ b/rpm/upload.sh
@@ -28,7 +28,7 @@ git clone https://github.com/iterative/rpm-s3 $RPM_S3_DIR --recurse-submodules
 rpm --resign $PKG
 
 export AWS_ACCESS_KEY=$(printenv AWS_ACCESS_KEY_ID)
-export AWS_SECRET_KEY=$(prinetnv AWS_SECRET_ACCESS_KEY)
+export AWS_SECRET_KEY=$(printenv AWS_SECRET_ACCESS_KEY)
 $RPM_S3_DIR/bin/rpm-s3 -vvv \
   --bucket $AWS_S3_BUCKET \
   --repopath $AWS_S3_PREFIX \


### PR DESCRIPTION
I suffered a digital[^1] race condition; yet another reason to regret https://github.com/iterative/dvc-s3-repo/pull/178#issuecomment-1717618399. 🐈⌨️ 

[^1]: [“digital: having to do with digits; performed with a finger”](https://en.wiktionary.org/wiki/digital#English)