### PR TITLE
docker: deb: install dotenv 2.8.1 for fpm

### DIFF
--- a/docker/deb/Dockerfile
+++ b/docker/deb/Dockerfile
@@ -54,6 +54,7 @@ RUN apt-get update && \
     apt-get install -y jq apt-transport-https && \
     rm -rf /var/lib/apt/lists/*
 
+RUN gem install dotenv -v 2.8.1
 RUN gem install fpm
 
 RUN pip --no-cache-dir install -U pip wheel

--- a/docker/rpm/Dockerfile
+++ b/docker/rpm/Dockerfile
@@ -51,6 +51,7 @@ RUN pip --no-cache install -U pip wheel
 # TODO: check if all of these dependencies are required
 RUN yum install -y wget jq yum-utils gnupg patch gdbm-devel ncurses-devel rpm-build
 
+RUN gem install dotenv -v 2.8.1
 RUN gem install fpm
 
 # NOTE: uploading with rpm-s3 requires python2, so we need to keep using fedora:26


### PR DESCRIPTION
```
Step 22/23 : RUN gem install fpm
 ---> Running in 9f43093191b9
ERROR:  Error installing fpm:
	The last version of dotenv (>= 0) to support your Ruby & RubyGems was 2.8.1. Try installing it with `gem install dotenv -v 2.8.1` and then running the current command again
```