### PR TITLE
Remove S3 ACL settings

### DIFF
--- a/env.sh
+++ b/env.sh
@@ -9,5 +9,5 @@ RPM_PKG="dvc-$VERSION-1.x86_64.rpm"
 DEB_PKG="dvc_""$VERSION""_amd64.deb"
 
 function upload_file {
-  aws s3 cp $1 s3://$AWS_S3_BUCKET/$2/ --acl public-read
+  aws s3 cp $1 s3://$AWS_S3_BUCKET/$2/
 }

--- a/rpm/upload.sh
+++ b/rpm/upload.sh
@@ -34,7 +34,6 @@ $RPM_S3_DIR/bin/rpm-s3 -vvv \
   --repopath $AWS_S3_PREFIX \
   --region $(printenv AWS_DEFAULT_REGION) \
   --keep 100 \
-  --visibility public-read \
   --sign \
   --gpg-bin gpg2 \
   --gpg-options="--no-tty --batch --passphrase $GPG_ITERATIVE_PASS  --pinentry-mode loopback" \


### PR DESCRIPTION
Since #282 we're writing to a bucket which doesn't support ACL (uses bucket policies instead)